### PR TITLE
added scope to vm module in main.bicep

### DIFF
--- a/bicep/managedvnet/main.bicep
+++ b/bicep/managedvnet/main.bicep
@@ -552,6 +552,7 @@ module privateEndpoints './modules/privateEndpoints.bicep' = {
 
 module virtualMachine './modules/virtualMachine.bicep' = {
   name: 'virtualMachine'
+  scope: resourceGroup(virtualNetworkResourceGroupName)
   params: {
     vmName: empty(vmName) ? toLower('${prefix}-jb-vm-${suffix}') : vmName
     vmNicName: empty(vmName) ? toLower('${prefix}-jb-nic-${suffix}') : vmName


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request adds a scope for the virtual machine created in `bicep/managdvnet/main.bicep` template. The rest of the updates are just turning end of line from CRLF to LF for all the text files.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```
